### PR TITLE
Fix: Link to documentation typo

### DIFF
--- a/packages/site/src/components/header/SiteHeader.tsx
+++ b/packages/site/src/components/header/SiteHeader.tsx
@@ -33,7 +33,7 @@ export default defineComponent({
             rel="noopener noreferrer"
             href="https://microsoft.github.io/monaco-editor"
           >
-            Monaco Ediotor Documentation
+            Monaco Editor Documentation
           </a>
         </div>
       </header>


### PR DESCRIPTION
### Description

Current documentation link has a typo on `Ediotor` -> `Editor` in the public demo.

### Screenshot

![image](https://github.com/imguolao/monaco-vue/assets/6007230/99f2793e-e0c0-40a7-9efb-d875bebdd3ef)
