### PR TITLE
refactor: export monaco types

### DIFF
--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -2,6 +2,7 @@ import loader from '@monaco-editor/loader'
 import VueMonacoEditor from './components/Editor'
 
 export type { EditorProps, VueMonacoEditorEmitsOptions } from './components/Editor'
+export type { MonacoEditor } from './types/index';
 
 export { install } from './install'
 export { useMonaco } from './hooks'


### PR DESCRIPTION
Sometime we need the editor types when using typescript, with this export we can use the types without install monaco-editor