### PR TITLE
fix: fix monaco editor version in peer-dependencies

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -52,7 +52,7 @@
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-terser": "^0.4.0",
     "esbuild": "^0.17.11",
-    "monaco-editor": "^0.43.0",
+    "monaco-editor": ">=0.43.0",
     "rimraf": "^4.1.2",
     "rollup": "^3.17.2",
     "rollup-plugin-dts": "^5.2.0",
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "@vue/composition-api": "^1.7.1",
-    "monaco-editor": "^0.43.0",
+    "monaco-editor": ">=0.43.0",
     "vue": "^2.6.14 || >=3.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
fix #49 